### PR TITLE
fix: 支払い履歴編集機能とテストの修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@playwright/test": "^1.54.1",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -3035,6 +3036,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@playwright/test": "^1.54.1",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/src/components/common/CollapsibleSection.tsx
+++ b/src/components/common/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 interface CollapsibleSectionProps {
   title: string;

--- a/src/components/sections/PaymentSection.tsx
+++ b/src/components/sections/PaymentSection.tsx
@@ -37,7 +37,6 @@ const PaymentSection: React.FC<PaymentSectionProps> = ({
 
   // 外部制御がある場合はそれを使用、ない場合は内部状態を使用
   const isFormOpen = onFormOpenChange ? externalIsFormOpen : internalIsFormOpen;
-  const setIsFormOpen = onFormOpenChange || setInternalIsFormOpen;
 
   const reset_form = () => {
     setFormData({
@@ -52,12 +51,12 @@ const PaymentSection: React.FC<PaymentSectionProps> = ({
 
 
   // 外部から制御される場合、externalIsFormOpenがtrueに変更されたときにフォームを開く
+  // 編集中でない場合のみフォームをリセット
   useEffect(() => {
-    if (onFormOpenChange && externalIsFormOpen) {
+    if (onFormOpenChange && externalIsFormOpen && !editingPayment) {
       reset_form();
-      setEditingPayment(null);
     }
-  }, [externalIsFormOpen, onFormOpenChange]);
+  }, [externalIsFormOpen, onFormOpenChange, editingPayment]);
 
   const open_edit_form = (payment: Payment) => {
     setFormData({
@@ -69,11 +68,22 @@ const PaymentSection: React.FC<PaymentSectionProps> = ({
     });
     setEditingPayment(payment);
     setErrors({});
-    setIsFormOpen(true);
+    
+    // 外部制御がある場合は外部状態を更新、ない場合は内部状態を更新
+    if (onFormOpenChange) {
+      onFormOpenChange(true);
+    } else {
+      setInternalIsFormOpen(true);
+    }
   };
 
   const close_form = () => {
-    setIsFormOpen(false);
+    // 外部制御がある場合は外部状態を更新、ない場合は内部状態を更新
+    if (onFormOpenChange) {
+      onFormOpenChange(false);
+    } else {
+      setInternalIsFormOpen(false);
+    }
     setEditingPayment(null);
     reset_form();
   };

--- a/src/tests/integration/components/MemberManagement.integration.test.tsx
+++ b/src/tests/integration/components/MemberManagement.integration.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Group from '../../../pages/Group';
 import type { Group as GroupType } from '../../../types/index.d.ts';
@@ -88,6 +89,8 @@ describe('Member Management Integration Tests', () => {
     });
 
     it('メンバーセクションの基本機能確認', async () => {
+      const user = userEvent.setup();
+      
       render(
         <MemoryRouter>
           <Group />
@@ -99,11 +102,22 @@ describe('Member Management Integration Tests', () => {
         expect(screen.getByTestId('group-name')).toBeInTheDocument();
       });
 
+      // デスクトップ用のメンバーボタンをクリックしてモーダルを開く
+      const memberButton = screen.getByTestId('desktop-members-button');
+      expect(memberButton).toBeInTheDocument();
+      
+      await user.click(memberButton);
+
+      // メンバー管理モーダルが開くまで待機
+      await waitFor(() => {
+        expect(screen.getByTestId('member-management-modal')).toBeInTheDocument();
+      });
+
       // メンバー追加フォームが表示される
       expect(screen.getByTestId('add-member-input')).toBeInTheDocument();
       expect(screen.getByTestId('add-member-button')).toBeInTheDocument();
 
-      // 既存メンバーが表示される（実際に表示されているものをテスト）
+      // 既存メンバーが表示される
       const memberItems = screen.getAllByTestId(/member-item-/);
       expect(memberItems.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
## Summary
- 支払い履歴編集時にフォームデータが正しく入力されない問題を修正
- メンバー管理テストの失敗を修正
- 型インポートエラーの修正

## Test plan
- [x] 支払い履歴の編集アイコンをクリックして、既存データがフォームに正しく入力されることを確認
- [x] 編集時のモーダルタイトルが「支払いを編集」となることを確認
- [x] すべてのテストが成功すること（139テスト）
- [x] ビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.ai/code)